### PR TITLE
fix(textinput): fix bug: in H5, clear() is not working

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,10 +44,8 @@ function TextInput(props, ref) {
   function setValue(value = '') {
     if (isWeex) {
       refEl.current.setAttr('value', value, false); // weex api.
-    } else if (refEl.current.setAttribute) {
-      refEl.current.setAttribute('value', value);
     } else {
-      refEl.current.attributes.value = value;
+      refEl.current.value = value;
     }
   }
 


### PR DESCRIPTION
the value of HTMLInputElement or HTMLTextAreaElement should not use setAttribute, see:
<https://stackoverflow.com/questions/29929797/setattribute-doesnt-work-the-way-i-expect-it-to>

-- 我在 Web 环境下跑 rax-textinput 的 demo 的时候发现无法通过 clear 方法来清除输入框的值，最后看源代码发现是因为这个原因：
<https://stackoverflow.com/questions/29929797/setattribute-doesnt-work-the-way-i-expect-it-to>
改掉后就可以了。
